### PR TITLE
Modbus 연결 타입에 따라 생성자 분리

### DIFF
--- a/PlcMachine/PlcMachine.csproj
+++ b/PlcMachine/PlcMachine.csproj
@@ -49,11 +49,15 @@
     <Compile Include="Comm\CommTcpClient.cs" />
     <Compile Include="Comm\CommTcpListenerSingle.cs" />
     <Compile Include="Comm\CommUdp.cs" />
+    <Compile Include="PlcMachineModbusUdp.cs" />
+    <Compile Include="PlcMachine\PlcMachineModbusTcp.cs" />
     <Compile Include="PlcMachine\MewtocolInterface\Mewtocol.cs" />
     <Compile Include="PlcMachine\MewtocolInterface\MewtocolLogWriter.cs" />
     <Compile Include="PlcMachine\ModbusInterface\Modbus.cs" />
     <Compile Include="PlcMachine\ModbusInterface\ModbusLogWriter.cs" />
-    <Compile Include="PlcMachine\ModbusInterface\ModbusType.cs" />
+    <Compile Include="PlcMachine\ConnectionType.cs" />
+    <Compile Include="PlcMachine\ModbusInterface\ModbusTcp.cs" />
+    <Compile Include="PlcMachine\ModbusInterface\ModbusUdp.cs" />
     <Compile Include="PlcMachine\PlcMachine.cs" />
     <Compile Include="PlcMachine\PlcMachineModbus.cs" />
     <Compile Include="PlcMachine\PlcMachineNone.cs" />

--- a/PlcMachine/PlcMachine/ConnectionType.cs
+++ b/PlcMachine/PlcMachine/ConnectionType.cs
@@ -1,0 +1,8 @@
+﻿namespace PlcUtil.PlcMachine
+{
+    public enum ConnectionType
+    {
+        Tcp,
+        Udp
+    }
+}

--- a/PlcMachine/PlcMachine/ModbusInterface/Modbus.cs
+++ b/PlcMachine/PlcMachine/ModbusInterface/Modbus.cs
@@ -1,59 +1,22 @@
 ﻿using NModbus;
 using System;
-using System.Net.Sockets;
 using System.Threading;
 
 namespace ModbusInterface
 {
-    public class Modbus
+    public abstract class Modbus
     {
-        private ModbusLogWriter m_logWriter;
+        protected ModbusLogWriter m_logWriter;
 
-        private string m_ipAddress;
-        private const int PORT = 502;
-        private ModbusType m_type;
-
-        private TcpClient m_tcpClient;
-        private UdpClient m_udpClient;
-        private ModbusFactory m_factory;
-        private IModbusMaster m_master;
+        protected ModbusFactory m_factory;
+        protected IModbusMaster m_master;
 
         public int WriteTimeout = Timeout.Infinite;
         public int ReadTimeout = Timeout.Infinite;
 
-        public Modbus(string ip, ModbusType type)
-        {
-            m_logWriter = new ModbusLogWriter(ip, PORT);
+        public abstract void Start();
 
-            m_ipAddress = ip;
-            m_type = type;
-        }
-
-        public void Start()
-        {
-            switch (m_type)
-            {
-                default:
-                case ModbusType.Tcp:
-                    m_tcpClient = new TcpClient(m_ipAddress, PORT);
-                    m_tcpClient.ReceiveTimeout = ReadTimeout;
-                    m_factory = new ModbusFactory();
-                    m_master = m_factory.CreateMaster(m_tcpClient);
-                    break;
-                case ModbusType.Udp:
-                    m_udpClient = new UdpClient(m_ipAddress, PORT);
-                    m_factory = new ModbusFactory();
-                    m_master = m_factory.CreateMaster(m_udpClient);
-                    break;
-
-            }
-        }
-
-        public void Stop()
-        {
-            m_tcpClient?.Close();
-            m_udpClient?.Close();
-        }
+        public abstract void Stop();
 
         public bool ReadCoil(ushort address, out bool data)
         {

--- a/PlcMachine/PlcMachine/ModbusInterface/ModbusTcp.cs
+++ b/PlcMachine/PlcMachine/ModbusInterface/ModbusTcp.cs
@@ -1,0 +1,34 @@
+﻿using NModbus;
+using System.Net.Sockets;
+
+namespace ModbusInterface
+{
+    public class ModbusTcp : Modbus
+    {
+        private string m_ipAddress;
+        private int m_port;
+
+        private TcpClient m_tcpClient;
+
+        public ModbusTcp(string ip, int port) : base()
+        {
+            m_logWriter = new ModbusLogWriter(ip, port);
+
+            m_ipAddress = ip;
+            m_port = port;
+        }
+
+        public override void Start()
+        {
+            m_tcpClient = new TcpClient(m_ipAddress, m_port);
+            m_tcpClient.ReceiveTimeout = ReadTimeout;
+            m_factory = new ModbusFactory();
+            m_master = m_factory.CreateMaster(m_tcpClient);
+        }
+
+        public override void Stop()
+        {
+            m_tcpClient?.Close();
+        }
+    }
+}

--- a/PlcMachine/PlcMachine/ModbusInterface/ModbusType.cs
+++ b/PlcMachine/PlcMachine/ModbusInterface/ModbusType.cs
@@ -1,8 +1,0 @@
-﻿namespace ModbusInterface
-{
-    public enum ModbusType
-    {
-        Tcp,
-        Udp
-    }
-}

--- a/PlcMachine/PlcMachine/ModbusInterface/ModbusUdp.cs
+++ b/PlcMachine/PlcMachine/ModbusInterface/ModbusUdp.cs
@@ -1,0 +1,33 @@
+﻿using NModbus;
+using System.Net.Sockets;
+
+namespace ModbusInterface
+{
+    public class ModbusUdp : Modbus
+    {
+        private string m_ipAddress;
+        private int m_port;
+
+        private UdpClient m_udpClient;
+
+        public ModbusUdp(string ip, int port) : base()
+        {
+            m_logWriter = new ModbusLogWriter(ip, port);
+
+            m_ipAddress = ip;
+            m_port = port;
+        }
+
+        public override void Start()
+        {
+            m_udpClient = new UdpClient(m_ipAddress, m_port);
+            m_factory = new ModbusFactory();
+            m_master = m_factory.CreateMaster(m_udpClient);
+        }
+
+        public override void Stop()
+        {
+            m_udpClient?.Close();
+        }
+    }
+}

--- a/PlcMachine/PlcMachine/PlcMachineModbusTcp.cs
+++ b/PlcMachine/PlcMachine/PlcMachineModbusTcp.cs
@@ -1,0 +1,16 @@
+﻿using ModbusInterface;
+
+namespace PlcUtil.PlcMachine
+{
+    /// <summary>
+    /// Modbus Tcp 통신 PlcMachine
+    /// </summary>
+    public class PlcMachineModbusTcp : PlcMachineModbus
+    {
+        public PlcMachineModbusTcp(string ipAddress, int port, int timeout = 5000) : base()
+        {
+            m_modbus = new ModbusTcp(ipAddress, port);
+            m_modbus.WriteTimeout = m_modbus.ReadTimeout = timeout;
+        }
+    }
+}

--- a/PlcMachine/PlcMachineModbusUdp.cs
+++ b/PlcMachine/PlcMachineModbusUdp.cs
@@ -1,0 +1,16 @@
+﻿using ModbusInterface;
+
+namespace PlcUtil.PlcMachine
+{
+    /// <summary>
+    /// Modbus Ucp 통신 PlcMachine
+    /// </summary>
+    public class PlcMachineModbusUdp : PlcMachineModbus
+    {
+        public PlcMachineModbusUdp(string ipAddress, int port, int timeout = 5000) : base()
+        {
+            m_modbus = new ModbusUdp(ipAddress, port);
+            m_modbus.WriteTimeout = m_modbus.ReadTimeout = timeout;
+        }
+    }
+}


### PR DESCRIPTION
Tcp/Udp는 파라미터가 동일하여 상속 클래스 분리하여 적용