### PR TITLE
최초로 값을 요청한 주소의 경우 스캔 완료 대기하여 실제 값 반환하도록 변경

### DIFF
--- a/PlcMachine/PlcMachine/PlcMachine.cs
+++ b/PlcMachine/PlcMachine/PlcMachine.cs
@@ -368,5 +368,31 @@ namespace PlcUtil.PlcMachine
         /// <param name="address">영역 주소</param>
         /// <param name="value">int 영역 값</param>
         public abstract void SetWordData(int address, int value);
+
+        /// <summary>
+        /// 스캔이 완료될 때 까지 대기하는 함수
+        /// </summary>
+        /// <returns></returns>
+        public void WaitScanComplete()
+        {
+            int count = 2;
+            var tcs = new TaskCompletionSource<bool>();
+            void Handler()
+            {
+                count--;
+                if (count <= 0)
+                    tcs.TrySetResult(true);
+            }
+
+            try
+            {
+                OnDataUpdated += Handler;
+                tcs.Task.GetAwaiter().GetResult();
+            }
+            finally
+            {
+                OnDataUpdated -= Handler;
+            }
+        }
     }
 }

--- a/PlcMachine/PlcMachine/PlcMachineModbus.cs
+++ b/PlcMachine/PlcMachine/PlcMachineModbus.cs
@@ -91,7 +91,8 @@ namespace PlcUtil.PlcMachine
 
             if (!_bitDataDict.TryGetValue(COIL, out var bitData))
                 return;
-            m_scanAddressData.SetScanAddress(COIL, uAddress, 1, BIT_SCAN_SIZE);
+            if (m_scanAddressData.SetScanAddress(COIL, uAddress, 1, BIT_SCAN_SIZE))
+                WaitScanComplete();
 
             value = bitData.GetData(uAddress, 1)[0];
         }
@@ -114,7 +115,8 @@ namespace PlcUtil.PlcMachine
             value = string.Empty;
             if (!_wordDataDict.TryGetValue(HOLDING_REGISTER, out var plcData))
                 return;
-            m_scanAddressData.SetScanAddress(HOLDING_REGISTER, address, length, WORD_SCAN_SIZE);
+            if (m_scanAddressData.SetScanAddress(HOLDING_REGISTER, address, length, WORD_SCAN_SIZE))
+                WaitScanComplete();
 
             ushort[] data = plcData.GetData(address, length);
             var sb = new StringBuilder();
@@ -135,7 +137,8 @@ namespace PlcUtil.PlcMachine
             value = 0;
             if (!_wordDataDict.TryGetValue(HOLDING_REGISTER, out var plcData))
                 return;
-            m_scanAddressData.SetScanAddress(HOLDING_REGISTER, address, 1, WORD_SCAN_SIZE);
+            if (m_scanAddressData.SetScanAddress(HOLDING_REGISTER, address, 1, WORD_SCAN_SIZE))
+                WaitScanComplete();
 
             ushort data = plcData.GetData(address, 1)[0];
             value = (short)data;
@@ -146,7 +149,8 @@ namespace PlcUtil.PlcMachine
             value = 0;
             if (!_wordDataDict.TryGetValue(HOLDING_REGISTER, out var plcData))
                 return;
-            m_scanAddressData.SetScanAddress(HOLDING_REGISTER, address, 2, WORD_SCAN_SIZE);
+            if (m_scanAddressData.SetScanAddress(HOLDING_REGISTER, address, 2, WORD_SCAN_SIZE))
+                WaitScanComplete();
 
             ushort[] data = plcData.GetData(address, 2);
             value = (data[1] << 16) | data[0];

--- a/PlcMachine/PlcMachine/PlcMachineOmron.cs
+++ b/PlcMachine/PlcMachine/PlcMachineOmron.cs
@@ -87,7 +87,8 @@ namespace PlcUtil.PlcMachine
             value = string.Empty;
             if (!_wordDataDict.TryGetValue(DM, out var wordData))
                 return;
-            m_scanAddressData.SetScanAddress(DM, address, length, SCAN_SIZE);
+            if (m_scanAddressData.SetScanAddress(DM, address, length, SCAN_SIZE))
+                WaitScanComplete();
 
             ushort[] data = wordData.GetData(address, length);
             StringBuilder sb = new StringBuilder();
@@ -108,7 +109,8 @@ namespace PlcUtil.PlcMachine
             value = 0;
             if (!_wordDataDict.TryGetValue(DM, out var wordData))
                 return;
-            m_scanAddressData.SetScanAddress(DM, address, 1, SCAN_SIZE);
+            if (m_scanAddressData.SetScanAddress(DM, address, 1, SCAN_SIZE))
+                WaitScanComplete();
 
             ushort data = wordData.GetData(address, 1)[0];
             value = (short)data;
@@ -119,7 +121,8 @@ namespace PlcUtil.PlcMachine
             value = 0;
             if (!_wordDataDict.TryGetValue(DM, out var wordData))
                 return;
-            m_scanAddressData.SetScanAddress(DM, address, 2, SCAN_SIZE);
+            if (m_scanAddressData.SetScanAddress(DM, address, 2, SCAN_SIZE))
+                WaitScanComplete();
 
             ushort[] data = wordData.GetData(address, 2);
             value = (data[1] << 16) | data[0];

--- a/PlcMachine/PlcMachine/PlcMachinePanasonic.cs
+++ b/PlcMachine/PlcMachine/PlcMachinePanasonic.cs
@@ -116,7 +116,8 @@ namespace PlcUtil.PlcMachine
 
             if (!_bitDataDict.TryGetValue(contactCode, out var bitData) || !int.TryParse(sContactAddress, out int contactAddress) || !TryParseHexToInt(sHex, out int hex))
                 return;
-            m_scanAddressData.SetScanAddress(contactCode, contactAddress, 1, SCAN_SIZE);
+            if (m_scanAddressData.SetScanAddress(contactCode, contactAddress, 1, SCAN_SIZE))
+                WaitScanComplete();
 
             value = bitData.GetData(contactAddress * 16 + hex, 1)[0];
         }
@@ -143,7 +144,8 @@ namespace PlcUtil.PlcMachine
             value = string.Empty;
             if (!_wordDataDict.TryGetValue(DT, out var wordData))
                 return;
-            m_scanAddressData.SetScanAddress(DT, address, length, SCAN_SIZE);
+            if (m_scanAddressData.SetScanAddress(DT, address, length, SCAN_SIZE))
+                WaitScanComplete();
 
             ushort[] data = wordData.GetData(address, length);
             StringBuilder sb = new StringBuilder();
@@ -164,7 +166,8 @@ namespace PlcUtil.PlcMachine
             value = 0;
             if (!_wordDataDict.TryGetValue(DT, out var wordData))
                 return;
-            m_scanAddressData.SetScanAddress(DT, address, 1, SCAN_SIZE);
+            if (m_scanAddressData.SetScanAddress(DT, address, 1, SCAN_SIZE))
+                WaitScanComplete();
 
             ushort data = wordData.GetData(address, 1)[0];
             value = (short)data;
@@ -175,7 +178,8 @@ namespace PlcUtil.PlcMachine
             value = 0;
             if (!_wordDataDict.TryGetValue(DT, out var wordData))
                 return;
-            m_scanAddressData.SetScanAddress(DT, address, 2, SCAN_SIZE);
+            if (m_scanAddressData.SetScanAddress(DT, address, 2, SCAN_SIZE))
+                WaitScanComplete();
 
             ushort[] data = wordData.GetData(address, 2);
             value = (data[1] << 16) | data[0];


### PR DESCRIPTION
메모리의 값을 반환하는 것이기 때문에 스캔 등록되지 않은 영역 주소를 처음 요청할 경우 스캔되지 않은 값을 반환한다.
따라서 스캔 등록되지 않은 영역 주소를 처음 요청할 경우, 영역 등록 후 스캔 완료를 대기하여 반환한다.