### PR TITLE
Panasonic PLC input 영역 접점 Set 방지

### DIFF
--- a/PlcMachine/PlcMachine/PlcMachinePanasonic.cs
+++ b/PlcMachine/PlcMachine/PlcMachinePanasonic.cs
@@ -121,7 +121,7 @@ namespace PlcUtil.PlcMachine
                 return;
             m_scanAddressData.SetScanAddress(key, index / 16, 1, SCAN_SIZE);
 
-            if (m_mewtocol.SetDIOData(key, index / 16, index % 16, value))
+            if (key != X && m_mewtocol.SetDIOData(key, index / 16, index % 16, value))
                 _bitDataDict[key].SetData(index, new bool[] { value });
         }
 


### PR DESCRIPTION
Panasonic PLC input 접점(X) Set 방지
Input 영역은 통신으로 Set할 수 없기 때문이다.