### PR TITLE
연속 Word 데이터 한번에 Set 하는 기능 추가

### DIFF
--- a/PlcMachine/PlcMachine/PlcMachine.cs
+++ b/PlcMachine/PlcMachine/PlcMachine.cs
@@ -417,6 +417,54 @@ namespace PlcUtil.PlcMachine
             await Task.Run(() => SetWordDataInt(address, value));
         }
 
+        /// <param name="address">연속 영역 시작 주소</param>
+        /// <param name="value">연속 영역 값</param>
+        public abstract void SetWordDataContinuous(string address, ushort[] value);
+
+        public async Task SetWordDataContinuousAsync(string address, ushort[] value)
+        {
+            await Task.Run(() => SetWordDataContinuous(address, value));
+        }
+
+        public ushort[] GetContinuousWordData(string value, int length, ushort[] continuousValue)
+        {
+            var newValue = new ushort[continuousValue.Length + length];
+
+            if (value.Length % 2 != 0)
+                value += '\0';
+
+            while (value.Length < length * 2)
+                value += "\0\0";
+
+            ushort[] data = new ushort[length];
+            for (int i = 0; i < length; i++)
+                data[i] = (ushort)(value[1 + i * 2] << 8 | value[i * 2]);
+
+            Array.Copy(continuousValue, 0, newValue, 0, continuousValue.Length);
+            Array.Copy(data, 0, newValue, continuousValue.Length, data.Length);
+            return newValue;
+        }
+
+        public ushort[] GetContinuousWordData(short value, ushort[] continuousValue)
+        {
+            var newValue = new ushort[continuousValue.Length + 1];
+            Array.Copy(continuousValue, 0, newValue, 0, continuousValue.Length);
+            newValue[continuousValue.Length] = (ushort)value;
+            return newValue;
+        }
+
+        public ushort[] GetContinuousWordData(int value, ushort[] continuousValue)
+        {
+            var newValue = new ushort[continuousValue.Length + 2];
+            ushort[] data = new ushort[2];
+            data[0] = (ushort)(value & 0xFFFF);
+            data[1] = (ushort)((value >> 16) & 0xFFFF);
+
+            Array.Copy(continuousValue, 0, newValue, 0, continuousValue.Length);
+            Array.Copy(data, 0, newValue, continuousValue.Length, data.Length);
+            return newValue;
+        }
+
         /// <summary>
         /// 스캔이 완료될 때 까지 대기하는 함수
         /// </summary>

--- a/PlcMachine/PlcMachine/PlcMachineModbus.cs
+++ b/PlcMachine/PlcMachine/PlcMachineModbus.cs
@@ -200,6 +200,17 @@ namespace PlcUtil.PlcMachine
                 _wordDataDict[key].SetData(index, data);
         }
 
+        public override void SetWordDataContinuous(string address, ushort[] value)
+        {
+            if (!GetWordAddress(address, out string key, out int index))
+                return;
+            if (m_scanAddressData.SetScanAddress(key, index, value.Length, WORD_SCAN_SIZE))
+                WaitScanComplete();
+
+            if (key == HOLDING_REGISTER && m_modbus.WriteHoldingRegister((ushort)index, value))
+                _wordDataDict[key].SetData(index, value);
+        }
+
         protected bool GetBitAddress(string address, out string key, out ushort index)
         {
             key = string.Empty;

--- a/PlcMachine/PlcMachine/PlcMachineNone.cs
+++ b/PlcMachine/PlcMachine/PlcMachineNone.cs
@@ -60,5 +60,9 @@
         public override void SetWordDataInt(string address, int value)
         {
         }
+
+        public override void SetWordDataContinuous(string address, ushort[] value)
+        {
+        }
     }
 }

--- a/PlcMachine/PlcMachine/PlcMachineOmron.cs
+++ b/PlcMachine/PlcMachine/PlcMachineOmron.cs
@@ -172,6 +172,17 @@ namespace PlcUtil.PlcMachine
                 _wordDataDict[key].SetData(index, data);
         }
 
+        public override void SetWordDataContinuous(string address, ushort[] value)
+        {
+            if (!GetWordAddress(address, out string key, out int index))
+                return;
+            if (m_scanAddressData.SetScanAddress(key, index, value.Length, SCAN_SIZE))
+                WaitScanComplete();
+
+            if (m_upperLink.SetDMData(index, value.Length, value))
+                _wordDataDict[key].SetData(index, value);
+        }
+
         protected bool GetWordAddress(string address, out string key, out int index)
         {
             key = string.Empty;

--- a/PlcMachine/PlcMachine/PlcMachinePanasonic.cs
+++ b/PlcMachine/PlcMachine/PlcMachinePanasonic.cs
@@ -214,6 +214,17 @@ namespace PlcUtil.PlcMachine
                 _wordDataDict[key].SetData(index, data);
         }
 
+        public override void SetWordDataContinuous(string address, ushort[] value)
+        {
+            if (!GetWordAddress(address, out string key, out int index))
+                return;
+            if (m_scanAddressData.SetScanAddress(key, index, value.Length, SCAN_SIZE))
+                WaitScanComplete();
+
+            if (m_mewtocol.SetDTData(index, value.Length, value))
+                _wordDataDict[key].SetData(index, value);
+        }
+
         protected bool TryParseHexToInt(string hex, out int value)
         {
             value = 0;


### PR DESCRIPTION
연속되는 Word 데이터를 타입별로 각각 Set하게 되면 통신 딜레이가 많이 걸리게 된다.
따라서 연속되는 데이터를 통합하여 한번에 Set하는 기능을 추가하였다.