### PR TITLE
Scan Address 등록 시점 조정

### DIFF
--- a/PlcMachine/PlcMachine/PlcMachineModbus.cs
+++ b/PlcMachine/PlcMachine/PlcMachineModbus.cs
@@ -106,7 +106,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetBitAddress(address, out var key, out var index))
                 return;
-            m_scanAddressData.SetScanAddress(key, index, 1, BIT_SCAN_SIZE);
 
             if (key == COIL && m_modbus.WriteCoil(index, value))
                 _bitDataDict[key].SetData(index, new bool[] { value });
@@ -158,8 +157,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetWordAddress(address, out string key, out int index))
                 return;
-            if (m_scanAddressData.SetScanAddress(key, index, 2, WORD_SCAN_SIZE))
-                WaitScanComplete();
 
             if (value.Length % 2 != 0)
                 value += '\0';
@@ -179,8 +176,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetWordAddress(address, out string key, out int index))
                 return;
-            if (m_scanAddressData.SetScanAddress(key, index, 2, WORD_SCAN_SIZE))
-                WaitScanComplete();
 
             ushort[] data = new ushort[] { (ushort)value };
             if (key == HOLDING_REGISTER && m_modbus.WriteHoldingRegister((ushort)index, data[0]))
@@ -191,8 +186,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetWordAddress(address, out string key, out int index))
                 return;
-            if (m_scanAddressData.SetScanAddress(key, index, 2, WORD_SCAN_SIZE))
-                WaitScanComplete();
 
             ushort[] data = new ushort[2];
             data[0] = (ushort)(value & 0xFFFF);
@@ -205,8 +198,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetWordAddress(address, out string key, out int index))
                 return;
-            if (m_scanAddressData.SetScanAddress(key, index, value.Length, WORD_SCAN_SIZE))
-                WaitScanComplete();
 
             if (key == HOLDING_REGISTER && m_modbus.WriteHoldingRegister((ushort)index, value))
                 _wordDataDict[key].SetData(index, value);

--- a/PlcMachine/PlcMachine/PlcMachineOmron.cs
+++ b/PlcMachine/PlcMachine/PlcMachineOmron.cs
@@ -131,8 +131,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetWordAddress(address, out string key, out int index))
                 return;
-            if (m_scanAddressData.SetScanAddress(key, index, 2, SCAN_SIZE))
-                WaitScanComplete();
 
             if (value.Length % 2 != 0)
                 value += '\0';
@@ -152,8 +150,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetWordAddress(address, out string key, out int index))
                 return;
-            if (m_scanAddressData.SetScanAddress(key, index, 2, SCAN_SIZE))
-                WaitScanComplete();
 
             ushort[] data = new ushort[] { (ushort)value };
             if (m_upperLink.SetDMData(index, 1, data))
@@ -164,8 +160,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetWordAddress(address, out string key, out int index))
                 return;
-            if (m_scanAddressData.SetScanAddress(key, index, 2, SCAN_SIZE))
-                WaitScanComplete();
 
             ushort[] data = new ushort[2];
             data[0] = (ushort)(value & 0xFFFF);
@@ -178,8 +172,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetWordAddress(address, out string key, out int index))
                 return;
-            if (m_scanAddressData.SetScanAddress(key, index, value.Length, SCAN_SIZE))
-                WaitScanComplete();
 
             if (m_upperLink.SetDMData(index, value.Length, value))
                 _wordDataDict[key].SetData(index, value);

--- a/PlcMachine/PlcMachine/PlcMachinePanasonic.cs
+++ b/PlcMachine/PlcMachine/PlcMachinePanasonic.cs
@@ -121,7 +121,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetBitAddress(address, out var key, out var index))
                 return;
-            m_scanAddressData.SetScanAddress(key, index / 16, 1, SCAN_SIZE);
 
             if (key != X && m_mewtocol.SetDIOData(key, index / 16, index % 16, value))
                 _bitDataDict[key].SetData(index, new bool[] { value });
@@ -173,8 +172,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetWordAddress(address, out string key, out int index))
                 return;
-            if (m_scanAddressData.SetScanAddress(key, index, 2, SCAN_SIZE))
-                WaitScanComplete();
 
             if (value.Length % 2 != 0)
                 value += '\0';
@@ -194,8 +191,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetWordAddress(address, out string key, out int index))
                 return;
-            if (m_scanAddressData.SetScanAddress(key, index, 2, SCAN_SIZE))
-                WaitScanComplete();
 
             ushort[] data = new ushort[] { (ushort)value };
             if (m_mewtocol.SetDTData(index, 1, data))
@@ -206,8 +201,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetWordAddress(address, out string key, out int index))
                 return;
-            if (m_scanAddressData.SetScanAddress(key, index, 2, SCAN_SIZE))
-                WaitScanComplete();
 
             ushort[] data = new ushort[2];
             data[0] = (ushort)(value & 0xFFFF);
@@ -220,8 +213,6 @@ namespace PlcUtil.PlcMachine
         {
             if (!GetWordAddress(address, out string key, out int index))
                 return;
-            if (m_scanAddressData.SetScanAddress(key, index, value.Length, SCAN_SIZE))
-                WaitScanComplete();
 
             if (m_mewtocol.SetDTData(index, value.Length, value))
                 _wordDataDict[key].SetData(index, value);


### PR DESCRIPTION
단순히 데이터를 Set 하기만 하고 확인은 하지 않는 경우도 존재한다.
그런 경우 Set 시점에서 Scan Address를 등록하여 스캔 루프를 추가하는 것은 불필요하다. 만약 Set하는 영역을 다시 확인도 하는 경우, Get 메서드에서 등록이 이루어질 것이기 때문에 Set 메서드에서는 ScanAddress를 등록하지 않는 것으로 변경한다.